### PR TITLE
Add support for RHN zipfiles installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ three options:
 - rpm
 - using your RHN credentials to retrieve the JWS zipfiles provided by Red Hat.
 
+Prerequisite
+----
+
+You'll need to install the role sabre1041.redhat-csp-download with ansible-galaxy in order to use this install method:
+
+    $ ansible-galaxy install sabre1041.redhat-csp-download
+
 Using local zipfiles
 ----
 
@@ -63,22 +70,17 @@ Change the default install method to RPM and provide the appropriate Tomcat HOME
 Using RHN
 ---
 
-You'll need to install the role sabre1041.redhat-csp-download with ansible-galaxy in order to use this install method:
 
-    $ ansible-galaxy install sabre1041.redhat-csp-download
-
-Then use the install method RHN zipfiles:
+To use the install method RHN zipfiles, simply set the method :
 
     vars:
        ...
        tomcat_install_method: rhn_zipfiles
 
-Provided your RHN credentials (as argument or in file):
+And provide your RHN credentials (as argument or in file):
 
     rhn_username: alice@wonderland.org
     rhn_password: eatme
-
-THIS METHOD IS NOT IMPLEMENTED YET
 
 Running the play books
 ===

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,10 +4,15 @@
   become: yes
   vars:
     tomcat_setup: true
+    # comment the next line if you another install method
     jws_version: 5.4.0
-    #uncomment the two next line if you want to install using RPM on a RHEL system.
+    # uncomment the two next line if you want to install using RPM on a RHEL system.
     #tomcat_install_method: rpm
     #tomcat_home: /opt/rh/jws5/root/usr/share/tomcat/
+    #
+    # uncomment the line below if you want to install fetching zipfiles from RHN directly
+    #tomcat_install_method: rhn_zipfiles
+    # note that workdir is only used when installing from zipfiles
     workdir: /opt
     tomcat_java_version: 1.8.0
     tomcat_vault:
@@ -19,7 +24,7 @@
       enable: "{{ override_tomcat_modcluster_enable | default('True') }}"
       ip: 127.0.0.1
       port: 6666
-
   roles:
     - tomcat
+    - sabre1041.redhat-csp-download
   tasks:

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -4,6 +4,11 @@ tomcat:
   supported_install_method: "local_zipfiles,rhn_zipfiles,rpm"
   install_method: "{{ tomcat_install_method | default('local_zipfiles') }}"
   rpm: "{{ override_tomcat_rpm | default('jws5') }}"
+  rhn:
+    server_zipfile_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=90341
+    native_zipfile_url: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=90361
+    username: "{{ rhn_username | default('') }}"
+    password: "{{ rhn_password | default('') }}"
   user: "{{ override_tomcat_user | default('tomcat_admin') }}"
   group: "{{ override_tomcat_group | default('tomcat') }}"
   home: "{{ tomcat_home | default('/opt/jws-5.4/tomcat') }}"

--- a/roles/tomcat/tasks/install.yml
+++ b/roles/tomcat/tasks/install.yml
@@ -77,7 +77,34 @@
 - block:
     - assert:
         that:
-          - tomcat.install_method == 'local_zipfiles' or tomcat.install_method == 'rpm'
+          - tomcat.rhn.server_zipfile_url is defined
+          - tomcat.rhn.server_zipfile_url | length > 0
+        quiet: true
+        fail_msg: "You need to provide"
+
+    - name: "Install JWS with zipfile from RHN: {{ tomcat.rhn.server_zipfile_url }}"
+      redhat_csp_download:
+        url: "{{ tomcat.rhn.server_zipfile_url }}"
+        dest: "{{  tomcat.home }}"
+        username: "{{ tomcat.rhn.username }}"
+        password: "{{ tomcat.rhn.password }}"
+
+    - name: "Install JWS native dependencies with zipfile from RHN: {{ tomcat.rhn.native_zipfile_url }}"
+      redhat_csp_download:
+        url: "{{ tomcat.rhn.native_zipfile_url }}"
+        dest: "{{  tomcat.home }}"
+        username: "{{ tomcat.rhn.username }}"
+        password: "{{ tomcat.rhn.password }}"
+      when:
+        - native_zipfile_url is defined
+        - native_zipfile_url | length > 0
+  when:
+    - tomcat.install_method == 'rhn_zipfiles'
+
+- block:
+    - assert:
+        that:
+          - tomcat.install_method == 'local_zipfiles' or tomcat.install_method == 'rpm' or tomcat_install_method == 'rhn_zipfiles'
         quiet: true
         fail_msg: "{{ tomcat.install_method }} is not yet supported"
   when:


### PR DESCRIPTION
@gzaronikas the install.yml is becoming quite big, I think I will ad a subfolder install/ with a file for each method (rpm, zipfiles, rhn). I will also investigate if we can skip the dependency to sabre1041.redhat-csp-download when the method used is not RHN.