### PR TITLE
Disable mod_cluster and vault

### DIFF
--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -36,13 +36,13 @@ tomcat:
       secret: "{{ override_tomcat_listen_ajp_secret | default('secret') }}"
   vault:
     name: "{{ override_tomcat_vault_name | default('vault.keystore') }}"
-    enable: "{{ override_tomcat_vault_enable | default('True') }}"
+    enable: "{{ override_tomcat_vault_enable | default('False') }}"
     alias: "{{ override_tomcat_vault_alias | default('my_vault') }}"
     storepass: "{{ override_tomcat_vault_storepass | default('123456') }}"
     iteration: "{{ override_tomcat_vault_iteration | default('44') }}"
     salt: "{{ override_tomcat_vault_salt  | default('1234abcd') }}"
     properties: "{{ override_tomcat_vault_properties | default('/conf/vault.properties') }}"
   mod_cluster:
-    enable: "{{ override_tomcat_modcluster_enable | default('True') }}"
+    enable: "{{ override_tomcat_modcluster_enable | default('False') }}"
     ip: "{{ override_tomcat_modcluster_ip | default('127.0.0.1') }}"
     port: "{{ override_tomcat_modcluster_port | default('6666') }}"


### PR DESCRIPTION
@gzaronikas rationale behind this change: those feature will break on plain Tomcat (by opposition to JWS), so as we want to provide "Tomcat install" support by default, it make sense to default those two to False.