### PR TITLE
Bump deps redhat_csp_download to 1.1.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -44,7 +44,7 @@ tags: [java, tomcat, server, apache, jws, mod_cluster]
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  middleware_automation.redhat_csp_download: '>=1.0'
+  middleware_automation.redhat_csp_download: '>=1.1.1'
 
 # The URL of the originating SCM repository
 repository: http://example.com/repository


### PR DESCRIPTION
@gzaronikas our 1.0.0 release of redhat_csp_download is broken, we forgot part of the packaging required by collection, so we need to bump the dependency to 1.1.1.